### PR TITLE
Public initialize for PinyinOutputFormat and capitalized castType support

### DIFF
--- a/HanziPinyin.xcodeproj/project.pbxproj
+++ b/HanziPinyin.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 		D395A12E1CC244BB00B76FB7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -294,6 +295,7 @@
 		D395A12F1CC244BB00B76FB7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;

--- a/HanziPinyin/PinyinFormatter.swift
+++ b/HanziPinyin/PinyinFormatter.swift
@@ -33,6 +33,8 @@ internal struct PinyinFormatter {
             formattedPinyin = formattedPinyin.lowercased()
         case .uppercase:
             formattedPinyin = formattedPinyin.uppercased()
+        case .capitalized:
+            formattedPinyin = formattedPinyin.capitalized
         }
 
         return formattedPinyin

--- a/HanziPinyin/PinyinOutputFormat.swift
+++ b/HanziPinyin/PinyinOutputFormat.swift
@@ -22,6 +22,7 @@ public enum PinyinVCharType {
 public enum PinyinCaseType {
     case lowercase
     case uppercase
+    case capitalized
 }
 
 public struct PinyinOutputFormat {

--- a/HanziPinyin/PinyinOutputFormat.swift
+++ b/HanziPinyin/PinyinOutputFormat.swift
@@ -32,4 +32,10 @@ public struct PinyinOutputFormat {
     public static var `default`: PinyinOutputFormat {
         return PinyinOutputFormat(toneType: .none, vCharType: .vCharacter, caseType: .lowercase)
     }
+    
+    public init(toneType: PinyinToneType, vCharType: PinyinVCharType, caseType: PinyinCaseType) {
+        self.toneType = toneType
+        self.vCharType = vCharType
+        self.caseType = caseType
+    }
 }


### PR DESCRIPTION
1、The initialize for PinyinOutputFormat is marked as `internal` by default, there is no way to create a customized PinyinOutputFormat.
2、And `capitalized` castType support for output.